### PR TITLE
Add bun tests for remark-spinster

### DIFF
--- a/packages/remark-spinster/__tests__/index.test.ts
+++ b/packages/remark-spinster/__tests__/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "bun:test";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import remarkSpinster from "../index";
+
+describe("remarkSpinster", () => {
+  it("capitalizes 'spinster' occurrences", async () => {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkSpinster)
+      .use(remarkStringify);
+    const result = await processor.process("hello spinster world");
+    expect(result.toString()).toBe("hello Spinster world\n");
+  });
+
+  it("ignores text without the keyword", async () => {
+    const processor = unified()
+      .use(remarkParse)
+      .use(remarkSpinster)
+      .use(remarkStringify);
+    const result = await processor.process("hello world");
+    expect(result.toString()).toBe("hello world\n");
+  });
+});


### PR DESCRIPTION
## Summary
- add a test suite for packages/remark-spinster using Bun's native test runner

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688261beaa788320898a69c25be548a1