### PR TITLE
Fix game store subscription

### DIFF
--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -2,7 +2,10 @@ import { useGameStore } from './store'
 import { visit } from 'unist-util-visit'
 
 // Initialize a passive subscription so the store is created
-useGameStore.subscribe(() => {})
+useGameStore.subscribe(
+  state => state.gameData,
+  () => {}
+)
 
 interface TextNode {
   type: 'text'

--- a/packages/utils/store.ts
+++ b/packages/utils/store.ts
@@ -1,5 +1,6 @@
 import { produce } from 'immer'
 import { create } from 'zustand'
+import { subscribeWithSelector } from 'zustand/middleware'
 
 export interface GameState<T = Record<string, unknown>> {
   /** Arbitrary game state */
@@ -17,8 +18,8 @@ interface InternalState<T> extends GameState<T> {
   _initialGameData: T
 }
 
-export const useGameStore = create<InternalState<Record<string, unknown>>>(
-  set => ({
+export const useGameStore = create(
+  subscribeWithSelector<InternalState<Record<string, unknown>>>(set => ({
     gameData: {},
     _initialGameData: {},
     init: data =>
@@ -36,5 +37,5 @@ export const useGameStore = create<InternalState<Record<string, unknown>>>(
       set(state => ({
         gameData: { ...state._initialGameData }
       }))
-  })
+  }))
 )


### PR DESCRIPTION
## Summary
- ensure store subscriptions target just the game data
- enable `subscribeWithSelector` for the game store

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_6884ee75afec832082a7de1f68384298